### PR TITLE
Remove problematic Require-Capability lines

### DIFF
--- a/geotools.gradle
+++ b/geotools.gradle
@@ -28,6 +28,10 @@ def geotools(String geotoolsVersion = '10.4',
 	}
 	
 	platform {
+	        bnd group: 'xpp3', name: 'xpp3_min', {
+	                instruction '-removeheaders', 'Require-Capability'
+	        }
+
 		feature id: 'platform.shared.geotools',
 				name: 'Geotools',
 				version: geotoolsVersion, {
@@ -69,6 +73,7 @@ def geotools(String geotoolsVersion = '10.4',
 			
 			// geotools depends on log4j
 			plugin group: 'log4j', name: 'log4j'
+
 		}
 	}
 }

--- a/orientdb.gradle
+++ b/orientdb.gradle
@@ -63,6 +63,10 @@ def orientCore(String orientDBVersion = Const.DEF_VERSION) {
 			instruction 'Import-Package', "com.orientechnologies.*;version=${orientDBVersion},*"
 			instruction 'Export-Package', "com.orientechnologies.*;version=${orientDBVersion},*"
 		}
+
+	        bnd name: 'concurrent', {
+        	        instruction '-removeheaders', 'Require-Capability'
+	        }
 		
 		feature id: 'platform.shared.orientdb.core',
 				name: 'OrientDB core',


### PR DESCRIPTION
The removed filter `(&(osgi.ee=JavaSE)(version=1.1))` causes validation errors in Eclipse product after the platform upgrade to Photon (halestudio/hale#659).