### PR TITLE
fix(geotools): replace deprecated Maven repository URL

### DIFF
--- a/geotools.gradle
+++ b/geotools.gradle
@@ -20,9 +20,6 @@ def geotools(String geotoolsVersion = '10.4',
 			url 'http://download.osgeo.org/webdav/geotools/'
 		}
 		maven {
-			url 'http://download.java.net/maven/2'
-		}
-		maven {
 			url 'https://repo.boundlessgeo.com/main/'
 		}
 	}


### PR DESCRIPTION
http://repo.opengeo.org was deprecated and replaced by http://repo.boundlessgeo.com/main

http://osgeo-org.1560.x6.nabble.com/repo-opengeo-org-deprecated-td5156221.html