### PR TITLE
Add support for newer GeoTools versions

### DIFF
--- a/geotools.gradle
+++ b/geotools.gradle
@@ -56,11 +56,15 @@ def geotools(String geotoolsVersion = '10.4',
 					instruction 'Export-Package', "org.geotools.*;version=$bundleVersion"
 					instruction 'Private-Package', '*'
 					
+					def tokenizedVersion = geotoolsVersion.tokenize('.|-')
+					def majorVersion = tokenizedVersion[0] as int
+					def jtsGeomPackage = (majorVersion < 20) ? 'com.vividsolutions.jts.geom' : 'org.locationtech.jts.geom'
+
 					prependImport(
 						// import eclipse xsd/emf w/o version (as the dependency does not export them)
 						'org.eclipse.xsd.*', 'org.eclipse.emf.*,',
 						// add missing imports that result in class loading issues
-						'com.vividsolutions.jts.geom' // because the package is also included in the bundle! (EmptyGeometry)
+						jtsGeomPackage // because the package is also included in the bundle! (EmptyGeometry)
 					)
 				}
 			}

--- a/geotools.gradle
+++ b/geotools.gradle
@@ -41,6 +41,11 @@ def geotools(String geotoolsVersion = '10.4',
 				if (it != 'gt-opengis') {
 					plugin "org.geotools:${it}:${geotoolsVersion}"
 				}
+				else if (it == 'geotools') {
+					plugin "org.getools:${it}:${geotoolsVersion}", {
+						exclude group: 'com.github.spotbugs', module 'spotbugs-annotation'
+					}
+				}
 			}
 			
 			// geotools bundle

--- a/postgis.gradle
+++ b/postgis.gradle
@@ -43,6 +43,8 @@ def postgis(String postgisVersion = '2.2.1', String postgresVersion = '42.2.4', 
 							it + ';resolution:=optional'
 						}.join(',')
 					}
+
+					prependImport 'waffle.*;resolution:=optional'
 					
 					// package export
 					// XXX any way to find out the actual resolved version?


### PR DESCRIPTION
GeoTools 20 and later uses a JTS version with the new core package `org.locationtech.jts`. This adds a version check to handle the `prependImport` based on the version number.

To avoid version conflicts also prevents importing of `javax.annotations` from spotbugs in the `geotools` module of newer GeoTools releases.